### PR TITLE
Fix for Rust 2021

### DIFF
--- a/ndless/src/bindings/ndless.rs
+++ b/ndless/src/bindings/ndless.rs
@@ -2,6 +2,8 @@
 //! This module contains functions that configure miscellaneous settings used in
 //! ndless.
 
+use core::arch::*;
+
 pub fn assert_ndless_rev(required_version: u32) {
 	unsafe { ndless_sys::assert_ndless_rev(required_version) }
 }
@@ -16,7 +18,7 @@ pub fn is_startup() -> bool {
 /// an actual calculator.
 pub fn bkpt() {
 	if cfg!(debug_assertions) {
-		unsafe { llvm_asm!(".long 0xE1212374") }
+		unsafe { asm!(".long 0xE1212374") }
 	}
 }
 

--- a/ndless/src/lib.rs
+++ b/ndless/src/lib.rs
@@ -7,7 +7,6 @@
 #![no_std]
 #![allow(clippy::tabs_in_doc_comments, clippy::needless_doctest_main)]
 #![feature(core_intrinsics)]
-#![feature(llvm_asm)]
 #![feature(never_type)]
 pub extern crate alloc;
 


### PR DESCRIPTION
Due to asm! being stabilized and used in favor of llvm_asm!, this has been changed to allow compilation on the latest Rust nightly

https://github.com/rust-lang/rfcs/pull/2873